### PR TITLE
chore: pin eslint to 4.12.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "clone": "^2.1.1",
     "coveralls": "^3.0.0",
     "css.escape": "^1.5.1",
-    "eslint": "^4.2.0",
+    "eslint": "4.12.1",
     "eslint-plugin-import": "^2.7.0",
     "express": "^4.16.2",
     "htmlescape": "^1.1.1",


### PR DESCRIPTION
4.13.0 contains a bug which breaks our build. See #6